### PR TITLE
Deprecate project for chocolatey/chocolatey-oneget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,1 @@
-# Chocolatey Provider for OneGet (C#)
-This will be the official Chocolatey provider for OneGet...
-
-## Development Requires: 
-    - vs 2013 
-    - YOU MUST BE RUNNING THE Experimental build of ONEGET : http://oneget.org/install-oneget.exe 
-    - or any official OneGet build from February 2015 or later.
-
-## Chat Room
-
-Come join in the conversation about Chocolatey in our Gitter Chat Room
-
-[![Join the chat at https://gitter.im/chocolatey/chocolatey-oneget](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/chocolatey/chocolatey-oneget?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
-Or, you can find us in IRC at #chocolatey.
+This is deprecated - Please go to https://github.com/chocolatey/chocolatey-oneget


### PR DESCRIPTION
The new official location is at https://github.com/chocolatey/chocolatey-oneget. 
Deprecated the project in the readme.